### PR TITLE
Add myHerb sustainability advisor prototype (CLI + web) with tests and README docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,3 +118,53 @@ By designing software with sustainability as a guiding principle, developers can
 DevSphere invites developers from diverse backgrounds and regions to join the initiative and actively participate in the shared mission of fostering sustainable software development. Together, the community can create a significant and positive impact on the environment, advocate for a more sustainable future within the software industry, and inspire others to embrace similar practices. 
 
 Let us unite our skills and expertise to develop software for a greener tomorrow. 🌿vvvvvvvvvvvvvvvvvvvv
+
+## 🌿 myHerb Sustainability Shift Guidance (Prototype)
+
+To help founders move from sustainability ambition to measurable action, DevSphere now includes a lightweight prototype in `apps/myherb_shift_advisor.py`.
+
+### What it does
+- Scores six core sustainability pillars (energy, water, waste, packaging, supply chain, community).
+- Produces a weighted sustainability maturity score.
+- Classifies organizations into a maturity tier (`Starter`, `Emerging`, `Progressing`, `Leader`).
+- Suggests top 3 priority areas for the next sustainability shift sprint.
+
+### Quick run
+```bash
+python apps/myherb_shift_advisor.py
+```
+
+### Watch a sustainability journey (quarter-by-quarter)
+```bash
+python apps/myherb_shift_advisor.py --watch
+```
+Use `--interval` to control playback speed and `--loop` for continuous mode:
+```bash
+python apps/myherb_shift_advisor.py --watch --interval 0.5 --loop
+```
+
+### Try it with your own scores (interactive)
+```bash
+python apps/myherb_shift_advisor.py --interactive
+```
+
+### Run tests
+```bash
+cd apps && python -m unittest test_myherb_shift_advisor.py
+```
+
+## 🌐 myHerb Website Experience (Modern Minimal Prototype)
+
+A new polished front-end experience is available at `apps/web/` to present myHerb as a professional, data-driven sustainability guidance platform.
+
+### Highlights
+- Modern and minimal Google-like aesthetic with soft gradients and clear typography.
+- Lightweight animations (floating insight card, dynamic score transitions, ambient glow).
+- Interactive sustainability assessment form with instant tier + recommendation output.
+- Responsive layout for desktop and mobile.
+
+### Run locally
+```bash
+python -m http.server 8080 -d apps/web
+```
+Then open: `http://localhost:8080`

--- a/apps/myherb_shift_advisor.py
+++ b/apps/myherb_shift_advisor.py
@@ -1,0 +1,256 @@
+"""myHerb Sustainability Shift Guidance Prototype.
+
+A lightweight CLI module to assess sustainability maturity and recommend
+prioritized next steps.
+"""
+
+from __future__ import annotations
+
+import argparse
+import time
+from dataclasses import dataclass
+from typing import Callable, Dict, Iterable, List
+
+
+PILLARS = (
+    "energy",
+    "water",
+    "waste",
+    "packaging",
+    "supply_chain",
+    "community",
+)
+
+
+@dataclass(frozen=True)
+class PillarAssessment:
+    """A maturity score for a sustainability pillar (0-100)."""
+
+    name: str
+    score: int
+
+    def __post_init__(self) -> None:
+        if self.name not in PILLARS:
+            raise ValueError(f"Unknown pillar: {self.name}")
+        if not 0 <= self.score <= 100:
+            raise ValueError("Score must be in the range 0..100")
+
+
+@dataclass
+class ShiftReport:
+    weighted_score: float
+    tier: str
+    priorities: List[str]
+
+
+def _default_weights() -> Dict[str, float]:
+    return {
+        "energy": 0.20,
+        "water": 0.15,
+        "waste": 0.20,
+        "packaging": 0.15,
+        "supply_chain": 0.20,
+        "community": 0.10,
+    }
+
+
+def _tier_from_score(score: float) -> str:
+    if score >= 80:
+        return "Leader"
+    if score >= 60:
+        return "Progressing"
+    if score >= 40:
+        return "Emerging"
+    return "Starter"
+
+
+def generate_shift_report(
+    assessments: List[PillarAssessment],
+    weights: Dict[str, float] | None = None,
+) -> ShiftReport:
+    """Generate a weighted sustainability shift report."""
+
+    if len(assessments) != len(PILLARS):
+        raise ValueError("All pillars must be assessed exactly once")
+
+    seen = {assessment.name for assessment in assessments}
+    if seen != set(PILLARS):
+        raise ValueError("Assessments must include each pillar exactly once")
+
+    resolved_weights = weights or _default_weights()
+    if set(resolved_weights) != set(PILLARS):
+        raise ValueError("Weights must include all pillars")
+
+    total_weight = sum(resolved_weights.values())
+    if abs(total_weight - 1.0) > 1e-9:
+        raise ValueError("Weights must sum to 1.0")
+
+    score_map = {assessment.name: assessment.score for assessment in assessments}
+    weighted_score = sum(score_map[p] * resolved_weights[p] for p in PILLARS)
+    tier = _tier_from_score(weighted_score)
+
+    underperforming = sorted(PILLARS, key=lambda p: score_map[p])[:3]
+    priorities = [
+        f"Increase {pillar.replace('_', ' ')} initiatives (current score: {score_map[pillar]})"
+        for pillar in underperforming
+    ]
+
+    return ShiftReport(
+        weighted_score=round(weighted_score, 2),
+        tier=tier,
+        priorities=priorities,
+    )
+
+
+def render_report(title: str, report: ShiftReport) -> str:
+    """Render a report as a console-friendly text block."""
+
+    priorities = "\n".join(f"- {item}" for item in report.priorities)
+    return (
+        f"\n{title}\n"
+        f"Weighted Score: {report.weighted_score}\n"
+        f"Tier: {report.tier}\n"
+        "Top priorities:\n"
+        f"{priorities}\n"
+    )
+
+
+def _assessments_from_scores(scores: Dict[str, int]) -> List[PillarAssessment]:
+    return [PillarAssessment(name=pillar, score=scores[pillar]) for pillar in PILLARS]
+
+
+def demo() -> ShiftReport:
+    """Return a sample report for showcasing the application idea."""
+
+    sample_scores = {
+        "energy": 55,
+        "water": 62,
+        "waste": 48,
+        "packaging": 45,
+        "supply_chain": 52,
+        "community": 70,
+    }
+    return generate_shift_report(_assessments_from_scores(sample_scores))
+
+
+def watch_sample_shift() -> Iterable[str]:
+    """Yield a simple quarter-by-quarter sustainability journey to watch progress."""
+
+    snapshots = [
+        (
+            "Quarter 1 (Baseline)",
+            {
+                "energy": 45,
+                "water": 54,
+                "waste": 40,
+                "packaging": 42,
+                "supply_chain": 47,
+                "community": 58,
+            },
+        ),
+        (
+            "Quarter 2 (Pilot Programs)",
+            {
+                "energy": 58,
+                "water": 60,
+                "waste": 52,
+                "packaging": 56,
+                "supply_chain": 54,
+                "community": 65,
+            },
+        ),
+        (
+            "Quarter 3 (Scale-Up)",
+            {
+                "energy": 68,
+                "water": 71,
+                "waste": 64,
+                "packaging": 66,
+                "supply_chain": 63,
+                "community": 72,
+            },
+        ),
+    ]
+
+    for label, scores in snapshots:
+        report = generate_shift_report(_assessments_from_scores(scores))
+        yield render_report(f"myHerb Sustainability Shift Guidance - {label}", report)
+
+
+def run_watch_mode(
+    interval_seconds: float = 1.5,
+    loop_forever: bool = False,
+    emit: Callable[[str], None] = print,
+    sleeper: Callable[[float], None] = time.sleep,
+) -> None:
+    """Stream watch snapshots with a configurable delay."""
+
+    if interval_seconds < 0:
+        raise ValueError("Watch interval must be >= 0")
+
+    while True:
+        for block in watch_sample_shift():
+            emit(block)
+            sleeper(interval_seconds)
+        if not loop_forever:
+            return
+
+
+def run_interactive_assessment() -> ShiftReport:
+    """Collect scores from a user in the terminal and generate a report."""
+
+    print("Enter your score for each pillar (0-100).")
+    scores: Dict[str, int] = {}
+    for pillar in PILLARS:
+        while True:
+            raw = input(f"{pillar.replace('_', ' ').title()}: ").strip()
+            try:
+                score = int(raw)
+                assessment = PillarAssessment(name=pillar, score=score)
+                scores[pillar] = assessment.score
+                break
+            except ValueError as error:
+                print(f"Invalid input: {error}")
+
+    return generate_shift_report(_assessments_from_scores(scores))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="myHerb Sustainability Shift Guidance")
+    parser.add_argument(
+        "--watch",
+        action="store_true",
+        help="Watch a quarter-by-quarter demo progression.",
+    )
+    parser.add_argument(
+        "--interactive",
+        action="store_true",
+        help="Enter your own pillar scores in the terminal.",
+    )
+    parser.add_argument(
+        "--interval",
+        type=float,
+        default=1.5,
+        help="Delay (seconds) between watch snapshots. Used with --watch.",
+    )
+    parser.add_argument(
+        "--loop",
+        action="store_true",
+        help="Repeat watch snapshots continuously. Used with --watch.",
+    )
+    args = parser.parse_args()
+
+    if args.watch:
+        run_watch_mode(interval_seconds=args.interval, loop_forever=args.loop)
+        return
+
+    if args.interactive:
+        report = run_interactive_assessment()
+        print(render_report("myHerb Sustainability Shift Guidance - Your Snapshot", report))
+        return
+
+    print(render_report("myHerb Sustainability Shift Guidance - Demo", demo()))
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/test_myherb_shift_advisor.py
+++ b/apps/test_myherb_shift_advisor.py
@@ -1,0 +1,91 @@
+import unittest
+
+from myherb_shift_advisor import (
+    PillarAssessment,
+    generate_shift_report,
+    render_report,
+    run_watch_mode,
+    watch_sample_shift,
+)
+
+
+class ShiftAdvisorTests(unittest.TestCase):
+    def test_report_generation(self):
+        assessments = [
+            PillarAssessment("energy", 80),
+            PillarAssessment("water", 70),
+            PillarAssessment("waste", 60),
+            PillarAssessment("packaging", 65),
+            PillarAssessment("supply_chain", 75),
+            PillarAssessment("community", 85),
+        ]
+
+        report = generate_shift_report(assessments)
+
+        self.assertEqual(report.tier, "Progressing")
+        self.assertAlmostEqual(report.weighted_score, 71.75)
+        self.assertEqual(len(report.priorities), 3)
+
+    def test_invalid_weight_sum(self):
+        assessments = [
+            PillarAssessment("energy", 80),
+            PillarAssessment("water", 70),
+            PillarAssessment("waste", 60),
+            PillarAssessment("packaging", 65),
+            PillarAssessment("supply_chain", 75),
+            PillarAssessment("community", 85),
+        ]
+
+        with self.assertRaises(ValueError):
+            generate_shift_report(
+                assessments,
+                {
+                    "energy": 0.1,
+                    "water": 0.1,
+                    "waste": 0.1,
+                    "packaging": 0.1,
+                    "supply_chain": 0.1,
+                    "community": 0.1,
+                },
+            )
+
+    def test_render_report_contains_basics(self):
+        assessments = [
+            PillarAssessment("energy", 80),
+            PillarAssessment("water", 70),
+            PillarAssessment("waste", 60),
+            PillarAssessment("packaging", 65),
+            PillarAssessment("supply_chain", 75),
+            PillarAssessment("community", 85),
+        ]
+        report = generate_shift_report(assessments)
+        output = render_report("Test", report)
+
+        self.assertIn("Weighted Score", output)
+        self.assertIn("Top priorities", output)
+
+    def test_watch_mode_has_three_snapshots(self):
+        snapshots = list(watch_sample_shift())
+
+        self.assertEqual(len(snapshots), 3)
+        self.assertIn("Quarter 1", snapshots[0])
+        self.assertIn("Quarter 3", snapshots[-1])
+
+    def test_run_watch_mode_emits_all_snapshots(self):
+        seen = []
+        run_watch_mode(
+            interval_seconds=0,
+            loop_forever=False,
+            emit=seen.append,
+            sleeper=lambda _: None,
+        )
+
+        self.assertEqual(len(seen), 3)
+
+    def test_run_watch_mode_rejects_negative_interval(self):
+        with self.assertRaises(ValueError):
+            run_watch_mode(interval_seconds=-0.5, sleeper=lambda _: None)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -1,0 +1,129 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="myHerb — Data-driven sustainability shift guidance with modern analytics and practical actions."
+    />
+    <title>myHerb | Sustainability Shift Guidance</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body>
+    <div class="bg-glow bg-glow--one" aria-hidden="true"></div>
+    <div class="bg-glow bg-glow--two" aria-hidden="true"></div>
+
+    <header class="topbar container">
+      <a class="brand" href="#">
+        <span class="brand__word"><em>my</em>Herb</span>
+        <svg class="brand__leaf" viewBox="0 0 64 45" aria-hidden="true">
+          <path
+            d="M6 21.8C24 24.6 35.8 18.8 49.1 4.9C48.4 18.5 41.2 31.2 26.1 35.7C16.1 38.7 9.3 34.1 6 21.8Z"
+          ></path>
+          <path
+            d="M30.7 29.2C40.8 31.3 47.9 28.4 57.6 18.2C56.9 28.3 52 37.5 42 40.7C35 43 31.3 39.7 30.7 29.2Z"
+          ></path>
+        </svg>
+      </a>
+      <nav class="topnav" aria-label="Primary">
+        <a href="#solution">Solution</a>
+        <a href="#impact">Impact</a>
+        <a href="#assess">Assessment</a>
+      </nav>
+    </header>
+
+    <main>
+      <section class="hero container" id="solution">
+        <div>
+          <p class="eyebrow">Data-driven sustainability shift guidance</p>
+          <h1>Build a greener business strategy with confidence.</h1>
+          <p class="lead">
+            myHerb blends measurable sustainability analytics with practical,
+            prioritized action plans. Minimal interface, maximum clarity.
+          </p>
+          <div class="hero__actions">
+            <a class="btn btn--primary" href="#assess">Start quick assessment</a>
+            <a class="btn btn--ghost" href="#impact">See impact model</a>
+          </div>
+          <ul class="metrics" aria-label="Key proof points">
+            <li><strong>6</strong><span>Core pillars</span></li>
+            <li><strong>3</strong><span>Top priorities per sprint</span></li>
+            <li><strong>&lt;2m</strong><span>To receive first guidance</span></li>
+          </ul>
+        </div>
+        <aside class="hero-card float">
+          <h2>Shift Snapshot</h2>
+          <p>Organization maturity:</p>
+          <p class="hero-card__tier" id="tierBadge">Progressing</p>
+          <p class="hero-card__score"><span id="scoreNumber">67.4</span>/100</p>
+          <div class="progress" role="img" aria-label="Current shift score">
+            <span id="progressBar"></span>
+          </div>
+          <p class="muted">Updated from your latest scenario simulation.</p>
+        </aside>
+      </section>
+
+      <section class="section container" id="impact">
+        <h2>Why teams choose myHerb</h2>
+        <div class="cards">
+          <article class="card">
+            <h3>Actionable intelligence</h3>
+            <p>
+              Translate scores into immediate decisions: what to fix now, what to
+              scale next, and what to monitor.
+            </p>
+          </article>
+          <article class="card">
+            <h3>Founder-ready simplicity</h3>
+            <p>
+              Designed in a clean, Google-like style that keeps complex
+              sustainability data understandable for every stakeholder.
+            </p>
+          </article>
+          <article class="card">
+            <h3>Guidance that inspires</h3>
+            <p>
+              Prioritized recommendations and progress storytelling help teams
+              maintain momentum and attract mission-aligned visitors.
+            </p>
+          </article>
+        </div>
+      </section>
+
+      <section class="section container" id="assess">
+        <div class="section__head">
+          <h2>Quick sustainability assessment</h2>
+          <p>Set each pillar from 0–100 and get your tailored shift guidance.</p>
+        </div>
+
+        <form id="assessmentForm" class="assess-grid">
+          <label>Energy <input type="number" min="0" max="100" value="58" name="energy" /></label>
+          <label>Water <input type="number" min="0" max="100" value="63" name="water" /></label>
+          <label>Waste <input type="number" min="0" max="100" value="47" name="waste" /></label>
+          <label>Packaging <input type="number" min="0" max="100" value="52" name="packaging" /></label>
+          <label>Supply chain <input type="number" min="0" max="100" value="60" name="supply_chain" /></label>
+          <label>Community <input type="number" min="0" max="100" value="71" name="community" /></label>
+          <button class="btn btn--primary" type="submit">Generate guidance</button>
+        </form>
+
+        <article class="result" id="result" aria-live="polite">
+          <h3>Recommendations</h3>
+          <p class="muted">Submit your assessment to view recommendations.</p>
+        </article>
+      </section>
+    </main>
+
+    <footer class="footer container">
+      <p>© <span id="year"></span> myHerb — Sustainable growth, intelligently guided.</p>
+    </footer>
+
+    <script src="./script.js"></script>
+  </body>
+</html>

--- a/apps/web/script.js
+++ b/apps/web/script.js
@@ -1,0 +1,100 @@
+const PILLARS = [
+  "energy",
+  "water",
+  "waste",
+  "packaging",
+  "supply_chain",
+  "community",
+];
+
+const WEIGHTS = {
+  energy: 0.2,
+  water: 0.15,
+  waste: 0.2,
+  packaging: 0.15,
+  supply_chain: 0.2,
+  community: 0.1,
+};
+
+const tierFromScore = (score) => {
+  if (score >= 80) return "Leader";
+  if (score >= 60) return "Progressing";
+  if (score >= 40) return "Emerging";
+  return "Starter";
+};
+
+const toNumber = (value) => {
+  const parsed = Number(value);
+  if (Number.isNaN(parsed)) return 0;
+  return Math.max(0, Math.min(100, parsed));
+};
+
+const computeReport = (scores) => {
+  const weightedScore = PILLARS.reduce(
+    (sum, pillar) => sum + toNumber(scores[pillar]) * WEIGHTS[pillar],
+    0,
+  );
+
+  const ordered = [...PILLARS].sort((a, b) => scores[a] - scores[b]).slice(0, 3);
+
+  const priorities = ordered.map(
+    (pillar) =>
+      `Increase ${pillar.replace("_", " ")} initiatives (current score: ${scores[pillar]})`,
+  );
+
+  return {
+    weightedScore: Number(weightedScore.toFixed(2)),
+    tier: tierFromScore(weightedScore),
+    priorities,
+  };
+};
+
+const scoreNode = document.getElementById("scoreNumber");
+const tierNode = document.getElementById("tierBadge");
+const progressNode = document.getElementById("progressBar");
+const resultNode = document.getElementById("result");
+const formNode = document.getElementById("assessmentForm");
+
+document.getElementById("year").textContent = new Date().getFullYear();
+
+const animateScore = (target) => {
+  const start = Number(scoreNode.textContent) || 0;
+  const durationMs = 700;
+  const begin = performance.now();
+
+  const tick = (now) => {
+    const progress = Math.min(1, (now - begin) / durationMs);
+    const current = start + (target - start) * progress;
+    scoreNode.textContent = current.toFixed(1);
+    if (progress < 1) requestAnimationFrame(tick);
+  };
+
+  requestAnimationFrame(tick);
+};
+
+const renderResult = (report) => {
+  const list = report.priorities.map((item) => `<li>${item}</li>`).join("");
+  resultNode.innerHTML = `
+    <h3>Your guidance output</h3>
+    <p><strong>Tier:</strong> ${report.tier} &nbsp;|&nbsp; <strong>Score:</strong> ${report.weightedScore}</p>
+    <p class="muted">Top 3 sustainability shift priorities:</p>
+    <ul>${list}</ul>
+  `;
+
+  tierNode.textContent = report.tier;
+  progressNode.style.width = `${report.weightedScore}%`;
+  animateScore(report.weightedScore);
+};
+
+formNode.addEventListener("submit", (event) => {
+  event.preventDefault();
+  const formData = new FormData(formNode);
+  const scores = Object.fromEntries(PILLARS.map((pillar) => [pillar, toNumber(formData.get(pillar))]));
+  renderResult(computeReport(scores));
+});
+
+window.addEventListener("load", () => {
+  const initialData = new FormData(formNode);
+  const scores = Object.fromEntries(PILLARS.map((pillar) => [pillar, toNumber(initialData.get(pillar))]));
+  renderResult(computeReport(scores));
+});

--- a/apps/web/styles.css
+++ b/apps/web/styles.css
@@ -1,0 +1,346 @@
+:root {
+  --bg: #f8fbfb;
+  --card: rgba(255, 255, 255, 0.72);
+  --text: #1f2933;
+  --muted: #5f6c75;
+  --brand: #6eaeb0;
+  --brand-dark: #4a8f92;
+  --ring: rgba(110, 174, 176, 0.33);
+  --border: rgba(145, 162, 171, 0.22);
+  --shadow: 0 20px 45px rgba(48, 68, 76, 0.12);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+  color: var(--text);
+  background: radial-gradient(circle at top right, #eef8f7 0%, var(--bg) 65%);
+  line-height: 1.6;
+  overflow-x: hidden;
+}
+
+.container {
+  width: min(1120px, calc(100% - 2rem));
+  margin: 0 auto;
+}
+
+.bg-glow {
+  position: fixed;
+  width: 30rem;
+  height: 30rem;
+  border-radius: 50%;
+  filter: blur(70px);
+  opacity: 0.35;
+  z-index: -1;
+  pointer-events: none;
+}
+
+.bg-glow--one {
+  background: #b8ece8;
+  top: -14rem;
+  right: -7rem;
+  animation: pulse 9s ease-in-out infinite;
+}
+
+.bg-glow--two {
+  background: #d7d3ff;
+  bottom: -14rem;
+  left: -10rem;
+  animation: pulse 11s ease-in-out infinite reverse;
+}
+
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.1rem 0;
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  text-decoration: none;
+  color: inherit;
+}
+
+.brand__word {
+  font-weight: 700;
+  font-size: clamp(1.2rem, 2vw, 1.7rem);
+  letter-spacing: -0.02em;
+}
+
+.brand__word em {
+  font-style: italic;
+  font-weight: 500;
+  color: #7b6a56;
+}
+
+.brand__leaf {
+  width: 2.45rem;
+  fill: var(--brand);
+}
+
+.topnav {
+  display: inline-flex;
+  gap: 1rem;
+}
+
+.topnav a {
+  text-decoration: none;
+  color: var(--muted);
+  font-weight: 500;
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: 1.15fr minmax(260px, 380px);
+  gap: 2rem;
+  align-items: center;
+  padding: 2.3rem 0 1.4rem;
+}
+
+.eyebrow {
+  display: inline-block;
+  padding: 0.3rem 0.7rem;
+  border-radius: 999px;
+  background: rgba(110, 174, 176, 0.13);
+  color: var(--brand-dark);
+  font-weight: 600;
+  font-size: 0.86rem;
+  margin-bottom: 0.8rem;
+}
+
+h1,
+h2,
+h3 {
+  line-height: 1.2;
+  margin: 0 0 0.6rem;
+}
+
+h1 {
+  font-size: clamp(2rem, 4.6vw, 3.4rem);
+  letter-spacing: -0.03em;
+}
+
+.lead {
+  font-size: 1.05rem;
+  color: var(--muted);
+  max-width: 58ch;
+}
+
+.hero__actions {
+  margin: 1.3rem 0 1.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem;
+}
+
+.btn {
+  border: 0;
+  text-decoration: none;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  padding: 0.73rem 1rem;
+  border-radius: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.btn--primary {
+  background: linear-gradient(140deg, var(--brand-dark), var(--brand));
+  color: #fff;
+  box-shadow: 0 12px 24px rgba(74, 143, 146, 0.2);
+}
+
+.btn--ghost {
+  background: transparent;
+  color: var(--brand-dark);
+  border: 1px solid var(--ring);
+}
+
+.metrics {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  gap: 1.6rem;
+}
+
+.metrics li {
+  display: grid;
+}
+
+.metrics strong {
+  font-size: 1.45rem;
+}
+
+.metrics span {
+  color: var(--muted);
+  font-size: 0.88rem;
+}
+
+.hero-card,
+.card,
+.result,
+.assess-grid {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 1.1rem;
+  backdrop-filter: blur(4px);
+}
+
+.hero-card {
+  padding: 1.2rem;
+  box-shadow: var(--shadow);
+}
+
+.hero-card__tier {
+  margin: 0;
+  font-size: 1.3rem;
+  font-weight: 700;
+}
+
+.hero-card__score {
+  margin: 0.15rem 0 0.75rem;
+  font-size: 1rem;
+  color: var(--muted);
+}
+
+.progress {
+  background: #edf3f4;
+  height: 0.58rem;
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.progress span {
+  display: block;
+  height: 100%;
+  width: 67.4%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--brand), #8dd7d9);
+  transition: width 480ms ease;
+}
+
+.section {
+  padding: 2rem 0;
+}
+
+.cards {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.card {
+  padding: 1rem;
+}
+
+.card p,
+.section__head p,
+.muted,
+label {
+  color: var(--muted);
+}
+
+.section__head {
+  margin-bottom: 1rem;
+}
+
+.assess-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.8rem;
+  padding: 1rem;
+}
+
+label {
+  display: grid;
+  font-size: 0.92rem;
+  gap: 0.35rem;
+}
+
+input {
+  border: 1px solid var(--border);
+  border-radius: 0.6rem;
+  padding: 0.6rem 0.7rem;
+  font: inherit;
+}
+
+input:focus {
+  outline: 2px solid var(--ring);
+  border-color: var(--brand);
+}
+
+.result {
+  margin-top: 0.9rem;
+  padding: 1rem;
+}
+
+.result ul {
+  margin: 0.45rem 0 0;
+  padding-left: 1.05rem;
+}
+
+.footer {
+  padding: 1.4rem 0 2.1rem;
+  color: var(--muted);
+  font-size: 0.92rem;
+}
+
+.float {
+  animation: floatCard 5.2s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.1);
+  }
+}
+
+@keyframes floatCard {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-8px);
+  }
+}
+
+@media (max-width: 960px) {
+  .hero {
+    grid-template-columns: 1fr;
+  }
+
+  .cards,
+  .assess-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+@media (max-width: 620px) {
+  .topnav {
+    display: none;
+  }
+
+  .cards,
+  .assess-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .metrics {
+    gap: 1rem;
+    flex-wrap: wrap;
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a lightweight prototype to help founders translate sustainability ambition into measurable, prioritized actions across six core pillars.
- Offer both a CLI-based assessor and a modern minimal web front-end to showcase the scoring, tiering, and sprint-priority recommendations.
- Document usage and testing so the prototype is easy to run and evaluate locally.

### Description
- Add `apps/myherb_shift_advisor.py` implementing `PillarAssessment` and `ShiftReport`, weighted scoring via `generate_shift_report`, demo/watch/interactive modes, and console rendering.
- Add unit tests in `apps/test_myherb_shift_advisor.py` that validate score aggregation, weight-sum validation, report rendering, watch snapshots, and interval handling.
- Add a simple static web prototype under `apps/web/` (`index.html`, `script.js`, `styles.css`) that provides an interactive assessment form, animated score display, and priority recommendations.
- Update `README.md` with usage instructions for the CLI, web preview, and test commands.

### Testing
- Ran the unit tests with `cd apps && python -m unittest test_myherb_shift_advisor.py`.
- All unit tests passed (6 tests executed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6c84698248322914088b12ae595e0)